### PR TITLE
Update validation of optional string properties

### DIFF
--- a/src/ProjectService.Business/Commands/Task/CreateTaskPropertyCommand.cs
+++ b/src/ProjectService.Business/Commands/Task/CreateTaskPropertyCommand.cs
@@ -23,12 +23,12 @@ namespace LT.DigitalOffice.ProjectService.Business.Commands
         private readonly IUserRepository _userRepository;
         private readonly ICreateTaskPropertyValidator _validator;
         private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly ITaskPropertyRepository _taskProperyRepository;
+        private readonly ITaskPropertyRepository _taskPropertyRepository;
 
         public CreateTaskPropertyCommand(
             IDbTaskPropertyMapper mapper,
             IAccessValidator accessValidator,
-            ITaskPropertyRepository taskProperyRepository,
+            ITaskPropertyRepository taskPropertyRepository,
             IUserRepository userRepository,
             ICreateTaskPropertyValidator validator,
             IHttpContextAccessor httpContextAccessor)
@@ -37,7 +37,7 @@ namespace LT.DigitalOffice.ProjectService.Business.Commands
             _validator = validator;
             _userRepository = userRepository;
             _accessValidator = accessValidator;
-            _taskProperyRepository = taskProperyRepository;
+            _taskPropertyRepository = taskPropertyRepository;
             _httpContextAccessor = httpContextAccessor;
         }
 
@@ -54,7 +54,7 @@ namespace LT.DigitalOffice.ProjectService.Business.Commands
 
             var dbTaskProperties = request.TaskProperties.Select(x => _mapper.Map(x, userId, request.ProjectId)).ToList();
 
-            _taskProperyRepository.Create(dbTaskProperties);
+            _taskPropertyRepository.Create(dbTaskProperties);
 
             return new OperationResultResponse<IEnumerable<Guid>>
             {

--- a/src/ProjectService.Mappers/RequestsMappers/DbProjectMapper.cs
+++ b/src/ProjectService.Mappers/RequestsMappers/DbProjectMapper.cs
@@ -23,9 +23,9 @@ namespace LT.DigitalOffice.ProjectService.Mappers.RequestsMappers
                 AuthorId = authorId,
                 Name = request.Name,
                 Status = (int)request.Status,
-                ShortName = request.ShortName,
-                Description = request.Description,
-                ShortDescription = request.ShortDescription,
+                ShortName = request.ShortName.Trim() == "" ? null : request.ShortName.Trim(),
+                Description = request.Description.Trim() == "" ? null : request.Description.Trim(),
+                ShortDescription = request.ShortDescription.Trim() == "" ? null : request.ShortDescription.Trim(),
                 DepartmentId = request.DepartmentId,
                 CreatedAt = DateTime.UtcNow,
                 Users = request.Users?

--- a/src/ProjectService.Mappers/RequestsMappers/DbProjectMapper.cs
+++ b/src/ProjectService.Mappers/RequestsMappers/DbProjectMapper.cs
@@ -16,16 +16,19 @@ namespace LT.DigitalOffice.ProjectService.Mappers.RequestsMappers
             }
 
             var projectId = Guid.NewGuid();
-
+            string shortName = request.ShortName?.Trim();
+            string description = request.Description?.Trim();
+            string shortDescription = request.ShortDescription?.Trim();
+            
             return new DbProject
             {
                 Id = projectId,
                 AuthorId = authorId,
                 Name = request.Name,
                 Status = (int)request.Status,
-                ShortName = request.ShortName.Trim() == "" ? null : request.ShortName.Trim(),
-                Description = request.Description.Trim() == "" ? null : request.Description.Trim(),
-                ShortDescription = request.ShortDescription.Trim() == "" ? null : request.ShortDescription.Trim(),
+                ShortName = shortName == null || !shortName.Any() ? null : shortName,
+                Description = description == null || !description.Any() ? null : description,
+                ShortDescription = shortDescription == null || !shortDescription.Any() ? null : shortDescription,
                 DepartmentId = request.DepartmentId,
                 CreatedAt = DateTime.UtcNow,
                 Users = request.Users?

--- a/src/ProjectService.Mappers/RequestsMappers/DbTaskMapper.cs
+++ b/src/ProjectService.Mappers/RequestsMappers/DbTaskMapper.cs
@@ -19,7 +19,7 @@ namespace LT.DigitalOffice.ProjectService.Mappers.RequestsMappers
             {
                 Id = Guid.NewGuid(),
                 Name = taskRequest.Name,
-                Description = taskRequest.Description,
+                Description = taskRequest.Description.Trim() == "" ? null : taskRequest.Description.Trim(),
                 PlannedMinutes = taskRequest.PlannedMinutes,
                 AssignedTo = taskRequest.AssignedTo,
                 AuthorId = authorId,

--- a/src/ProjectService.Mappers/RequestsMappers/DbTaskPropertyMapper.cs
+++ b/src/ProjectService.Mappers/RequestsMappers/DbTaskPropertyMapper.cs
@@ -22,7 +22,7 @@ namespace LT.DigitalOffice.ProjectService.Mappers.Models
                 Name = request.Name,
                 IsActive = true,
                 CreatedAt = DateTime.UtcNow,
-                Description = request.Description,
+                Description = request.Description.Trim() == "" ? null : request.Description.Trim(),
                 PropertyType = (int)request.PropertyType,
             };
         }

--- a/src/ProjectService.Validation/CreateProjectValidator.cs
+++ b/src/ProjectService.Validation/CreateProjectValidator.cs
@@ -20,7 +20,7 @@ namespace LT.DigitalOffice.ProjectService.Validation
             RuleFor(project => project.Status)
                 .IsInEnum();
 
-            When(project => !string.IsNullOrEmpty(project.ShortName), () =>
+            When(project => !string.IsNullOrEmpty(project.ShortName?.Trim()), () =>
             {
                 RuleFor(project => project.ShortName)
                     .MaximumLength(30)
@@ -39,14 +39,14 @@ namespace LT.DigitalOffice.ProjectService.Validation
                 });
             });
 
-            When(project => !string.IsNullOrEmpty(project.ShortDescription), () =>
+            When(project => !string.IsNullOrEmpty(project.ShortDescription?.Trim()), () =>
             {
                 RuleFor(project => project.ShortDescription)
                     .MaximumLength(300)
                     .WithMessage("Project short description is too long.");
             });
 
-            When(project => !string.IsNullOrEmpty(project.Description), () =>
+            When(project => !string.IsNullOrEmpty(project.Description?.Trim()), () =>
             {
                 RuleFor(project => project.Description)
                     .MaximumLength(300)

--- a/src/ProjectService.Validation/CreateProjectValidator.cs
+++ b/src/ProjectService.Validation/CreateProjectValidator.cs
@@ -20,7 +20,7 @@ namespace LT.DigitalOffice.ProjectService.Validation
             RuleFor(project => project.Status)
                 .IsInEnum();
 
-            When(project => !string.IsNullOrEmpty(project.ShortName.Trim()), () =>
+            When(project => !string.IsNullOrEmpty(project.ShortName), () =>
             {
                 RuleFor(project => project.ShortName)
                     .MaximumLength(30)
@@ -39,14 +39,14 @@ namespace LT.DigitalOffice.ProjectService.Validation
                 });
             });
 
-            When(project => !string.IsNullOrEmpty(project.ShortDescription.Trim()), () =>
+            When(project => !string.IsNullOrEmpty(project.ShortDescription), () =>
             {
                 RuleFor(project => project.ShortDescription)
                     .MaximumLength(300)
                     .WithMessage("Project short description is too long.");
             });
 
-            When(project => !string.IsNullOrEmpty(project.Description.Trim()), () =>
+            When(project => !string.IsNullOrEmpty(project.Description), () =>
             {
                 RuleFor(project => project.Description)
                     .MaximumLength(300)

--- a/src/ProjectService.Validation/CreateProjectValidator.cs
+++ b/src/ProjectService.Validation/CreateProjectValidator.cs
@@ -20,10 +20,9 @@ namespace LT.DigitalOffice.ProjectService.Validation
             RuleFor(project => project.Status)
                 .IsInEnum();
 
-            When(project => project.ShortName != null, () =>
+            When(project => !string.IsNullOrEmpty(project.ShortName.Trim()), () =>
             {
                 RuleFor(project => project.ShortName)
-                    .NotEmpty()
                     .MaximumLength(30)
                     .WithMessage("Project short name is too long.");
             });
@@ -40,20 +39,18 @@ namespace LT.DigitalOffice.ProjectService.Validation
                 });
             });
 
-            When(project => project.ShortDescription != null, () =>
+            When(project => !string.IsNullOrEmpty(project.ShortDescription.Trim()), () =>
             {
                 RuleFor(project => project.ShortDescription)
-                    .NotEmpty()
                     .MaximumLength(300)
                     .WithMessage("Project short description is too long.");
             });
 
-            When(project => project.Description != null, () =>
+            When(project => !string.IsNullOrEmpty(project.Description.Trim()), () =>
             {
                 RuleFor(project => project.Description)
-                    .NotEmpty()
                     .MaximumLength(300)
-                    .WithMessage("Project short description is too long.");
+                    .WithMessage("Project description is too long.");
             });
         }
     }

--- a/src/ProjectService.Validation/CreateTaskPropertyValidator.cs
+++ b/src/ProjectService.Validation/CreateTaskPropertyValidator.cs
@@ -23,7 +23,7 @@ namespace LT.DigitalOffice.ProjectService.Validation
                         tp.RuleFor(tp => tp.PropertyType)
                             .IsInEnum();
 
-                        tp.When(tp => !string.IsNullOrEmpty(tp.Description), () =>
+                        tp.When(tp => !string.IsNullOrEmpty(tp.Description?.Trim()), () =>
                         {
                             tp.RuleFor(tp => tp.Description)
                                 .MaximumLength(300)

--- a/src/ProjectService.Validation/CreateTaskPropertyValidator.cs
+++ b/src/ProjectService.Validation/CreateTaskPropertyValidator.cs
@@ -23,7 +23,7 @@ namespace LT.DigitalOffice.ProjectService.Validation
                         tp.RuleFor(tp => tp.PropertyType)
                             .IsInEnum();
 
-                        tp.When(tp => !string.IsNullOrEmpty(tp.Description.Trim()), () =>
+                        tp.When(tp => !string.IsNullOrEmpty(tp.Description), () =>
                         {
                             tp.RuleFor(tp => tp.Description)
                                 .MaximumLength(300)

--- a/src/ProjectService.Validation/CreateTaskPropertyValidator.cs
+++ b/src/ProjectService.Validation/CreateTaskPropertyValidator.cs
@@ -23,10 +23,11 @@ namespace LT.DigitalOffice.ProjectService.Validation
                         tp.RuleFor(tp => tp.PropertyType)
                             .IsInEnum();
 
-                        tp.When(tp => tp.Description != null, () =>
+                        tp.When(tp => !string.IsNullOrEmpty(tp.Description.Trim()), () =>
                         {
                             tp.RuleFor(tp => tp.Description)
-                                .NotEmpty();
+                                .MaximumLength(300)
+                                .WithMessage("Task property description is too long.");
                         });
                     })
                     .DependentRules(() =>

--- a/src/ProjectService.Validation/CreateTaskRequestValidator.cs
+++ b/src/ProjectService.Validation/CreateTaskRequestValidator.cs
@@ -19,7 +19,7 @@ namespace LT.DigitalOffice.ProjectService.Validation
                 .MaximumLength(150)
                 .WithMessage("Task name is too long.");
 
-            When(task => !string.IsNullOrEmpty(task.Description), () =>
+            When(task => !string.IsNullOrEmpty(task.Description?.Trim()), () =>
             {
                 RuleFor(task => task.Description)
                     .MaximumLength(300)

--- a/src/ProjectService.Validation/CreateTaskRequestValidator.cs
+++ b/src/ProjectService.Validation/CreateTaskRequestValidator.cs
@@ -19,9 +19,12 @@ namespace LT.DigitalOffice.ProjectService.Validation
                 .MaximumLength(150)
                 .WithMessage("Task name is too long.");
 
-            RuleFor(task => task.Description)
-                .NotEmpty()
-                .WithMessage("Task must have description.");
+            When(task => !string.IsNullOrEmpty(task.Description.Trim()), () =>
+            {
+                RuleFor(task => task.Description)
+                    .MaximumLength(300)
+                    .WithMessage("Task description is too long.");
+            });
 
             When(task => task.ParentId.HasValue, () =>
             {

--- a/src/ProjectService.Validation/CreateTaskRequestValidator.cs
+++ b/src/ProjectService.Validation/CreateTaskRequestValidator.cs
@@ -19,7 +19,7 @@ namespace LT.DigitalOffice.ProjectService.Validation
                 .MaximumLength(150)
                 .WithMessage("Task name is too long.");
 
-            When(task => !string.IsNullOrEmpty(task.Description.Trim()), () =>
+            When(task => !string.IsNullOrEmpty(task.Description), () =>
             {
                 RuleFor(task => task.Description)
                     .MaximumLength(300)

--- a/test/ProjectService.Validation.UnitTests/CreateProjectValidatorTests.cs
+++ b/test/ProjectService.Validation.UnitTests/CreateProjectValidatorTests.cs
@@ -54,27 +54,27 @@ namespace LT.DigitalOffice.ProjectService.Validation.UnitTests
         }
 
         [Test]
-        public void ShouldErrorWhenProjectShortNameIsEmpty()
+        public void ShouldNotErrorWhenProjectShortNameIsEmpty()
         {
-            _validator.ShouldHaveValidationErrorFor(x => x.ShortName, "");
+            _validator.ShouldNotHaveValidationErrorFor(x => x.ShortName, "");
         }
 
         [Test]
-        public void ShouldErrorsWhenProjectShortNameIsEmpty()
+        public void ShouldNotErrorsWhenProjectShortNameIsEmpty()
         {
-            _validator.ShouldHaveValidationErrorFor(x => x.ShortName, "");
+            _validator.ShouldNotHaveValidationErrorFor(x => x.ShortName, "");
         }
 
         [Test]
-        public void ShouldErrorWhenDescriptionIsEmpty()
+        public void ShouldNotErrorWhenDescriptionIsEmpty()
         {
-            _validator.ShouldHaveValidationErrorFor(x => x.Description, "");
+            _validator.ShouldNotHaveValidationErrorFor(x => x.Description, "");
         }
 
         [Test]
-        public void ShouldErrorWhenShortDescriptionIsEmpty()
+        public void ShouldNotErrorWhenShortDescriptionIsEmpty()
         {
-            _validator.ShouldHaveValidationErrorFor(x => x.ShortDescription, "");
+            _validator.ShouldNotHaveValidationErrorFor(x => x.ShortDescription, "");
         }
 
         [Test]

--- a/test/ProjectService.Validation.UnitTests/CreateTaskPropertyValidatorTests.cs
+++ b/test/ProjectService.Validation.UnitTests/CreateTaskPropertyValidatorTests.cs
@@ -87,7 +87,7 @@ namespace LT.DigitalOffice.ProjectService.Validation.UnitTests
         }
 
         [Test]
-        public void ShouldHaveValidationErrorWhenDescriptionIsEmpty()
+        public void ShouldNotHaveValidationErrorWhenDescriptionIsEmpty()
         {
             var newProperties = new List<TaskProperty>
             {
@@ -105,8 +105,7 @@ namespace LT.DigitalOffice.ProjectService.Validation.UnitTests
                 TaskProperties = newProperties
             };
 
-            _validator.TestValidate(request).ShouldHaveValidationErrorFor("TaskProperties[0].Description");
-            _repository.Verify(x => x.AreExistForProject(_request.ProjectId, It.IsAny<string[]>()), Times.Never);
+            _validator.TestValidate(request).ShouldNotHaveValidationErrorFor("TaskProperties[0].Description");
         }
 
         [Test]

--- a/test/ProjectService.Validation.UnitTests/CreateTaskValidationTests.cs
+++ b/test/ProjectService.Validation.UnitTests/CreateTaskValidationTests.cs
@@ -60,9 +60,9 @@ namespace LT.DigitalOffice.ProjectService.Validation.UnitTests
         }
 
         [Test]
-        public void ShouldErrorsWhenDescriptionIsEmpty()
+        public void ShouldNotErrorsWhenDescriptionIsEmpty()
         {
-            _validator.ShouldHaveValidationErrorFor(x => x.Description, "");
+            _validator.ShouldNotHaveValidationErrorFor(x => x.Description, "");
         }
 
         [Test]


### PR DESCRIPTION
1) Change validation of optional string properties from .NotEmpty() то When(p => !string.IsNullOrEmpty(p.Description)) { ... };
2) Add the check to the mapper if the value is empty set to null.